### PR TITLE
Bumped version number for NSA-7320 changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.validation",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.validation",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
NSA-7320 changes already approved here: https://github.com/DFE-Digital/login.dfe.validation/pull/12
This just bumps the version number for the addition of a few email domains.