### PR TITLE
NSA-9706-fix : added mail@ to blacklisted emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.validation",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/utils/blacklistedEmails.js
+++ b/utils/blacklistedEmails.js
@@ -167,6 +167,7 @@ const blacklistedEmails = [
   "manager@",
   "marketing@",
   "MIS@",
+  "mail@",
   "NBT.Claims@",
   "nursingschool@",
   "office@",


### PR DESCRIPTION
Added mail@ to the deny list so that emails these email name gets blocked due to being generic